### PR TITLE
fix: replace deprecated call to distutils copy_tree

### DIFF
--- a/src/vivado_build_service/client.py
+++ b/src/vivado_build_service/client.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import Tuple
 from contextlib import closing
-from distutils.dir_util import copy_tree
+from shutil import copytree as copy_tree
 import tomli
 
 from .vtrunner.streamutil import join_streams


### PR DESCRIPTION
many python distribution do not even ship distutils per default anymore. shutil should be used instead.