### PR TITLE
feat: print usage for command line client if called incorrectly

### DIFF
--- a/vbservice/client.py
+++ b/vbservice/client.py
@@ -14,11 +14,19 @@ import tomli
 
 from vbservice.src.streamutil import join_streams
 from vbservice.config import ClientConfig, GeneralConfig, default_general_config
-from vbservice.src.filehandler import get_filepaths, serialize, pack, unpack, deserialize
+from vbservice.src.filehandler import (
+    get_filepaths,
+    serialize,
+    pack,
+    unpack,
+    deserialize,
+)
 
 
 class Client:
-    def __init__(self, client_config: ClientConfig, general_config: GeneralConfig = None):
+    def __init__(
+        self, client_config: ClientConfig, general_config: GeneralConfig = None
+    ):
         self._logger = logging.getLogger(__name__)
 
         self.client_config = client_config
@@ -32,12 +40,12 @@ class Client:
 
     @classmethod
     def from_config(cls, path: Path):
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             config = tomli.load(f)
         config = ClientConfig(
-            server_port=int(config['server']['port']),
-            server_ip_address=config['server']['ip_address'],
-            queue_user=config['queue_user'],
+            server_port=int(config["server"]["port"]),
+            server_ip_address=config["server"]["ip_address"],
+            queue_user=config["queue_user"],
         )
         return cls(config)
 
@@ -45,12 +53,15 @@ class Client:
         self.download_dir = make_unique_dir(download_dir)
         request = self._prepare_request(upload_dir)
 
-        data = join_streams([
+        data = join_streams(
+            [
                 self.client_config.queue_user.encode(),
                 model_number.encode(),
                 str(int(only_bin_files)).encode(),
-                request
-        ], self.general_config.delimiter.encode())
+                request,
+            ],
+            self.general_config.delimiter.encode(),
+        )
         s = self._connect_with_socket()
         response = self._send_and_receive(s, data)
 
@@ -61,9 +72,11 @@ class Client:
         if not bin_files or len(bin_files) == 0:
             print("\nAn Error occurred. No bin file could be found.")
         for bf in bin_files:
-            if 'failure' in bf:
-                print(f"\nAn Error occurred. Read Vivado Run Log file for more information:"
-                      f"\n{result_dir}/vivado_run.log")
+            if "failure" in bf:
+                print(
+                    f"\nAn Error occurred. Read Vivado Run Log file for more information:"
+                    f"\n{result_dir}/vivado_run.log"
+                )
                 print("failure.bin content:\n")
                 time.sleep(1)
                 with open(bf, "r") as f:
@@ -74,7 +87,7 @@ class Client:
         ssh_command = "ssh -Y -L {}:localhost:{} vivado@{}".format(
             self.client_config.server_port,
             self.client_config.server_port,
-            self.client_config.server_ip_address
+            self.client_config.server_ip_address,
         )
         subprocess.Popen(ssh_command, creationflags=subprocess.CREATE_NEW_CONSOLE)
 
@@ -82,21 +95,23 @@ class Client:
         loading_animation = threading.Thread(target=self._print_loading_animation)
         loading_animation.start()
         inputs, outputs = [s], [s]
-        response = b''
+        response = b""
 
         while inputs:
-            readable, writable, exceptional = select.select(inputs, outputs, inputs, 0.5)
+            readable, writable, exceptional = select.select(
+                inputs, outputs, inputs, 0.5
+            )
 
             for s in writable:
-                self._logger.info('Sending...\n')
+                self._logger.info("Sending...\n")
                 s.send(data)
-                self._logger.info('Sent!')
+                self._logger.info("Sent!")
                 outputs.remove(s)
 
             for s in readable:
                 chunk = s.recv(self.general_config.chunk_size)
                 if not chunk:
-                    self._logger.info('Closing...')
+                    self._logger.info("Closing...")
                     inputs.remove(s)
                     s.close()
                     break
@@ -104,26 +119,26 @@ class Client:
                 response += chunk
 
             for s in exceptional:
-                self._logger.info('Error')
+                self._logger.info("Error")
                 inputs.remove(s)
                 outputs.remove(s)
                 break
 
-        loading_animation.join(.1)
+        loading_animation.join(0.1)
         return response
 
     def _connect_with_socket(self) -> socket.socket | None:
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-            self._logger.info('Connecting...')
+            self._logger.info("Connecting...")
             ret = s.connect_ex(("localhost", self.client_config.server_port))
 
             if ret != 0:
-                self._logger.info('Failed to connect!\n\n')
+                self._logger.info("Failed to connect!\n\n")
                 raise ConnectionError
 
-            self._logger.info('Connected!\n\n')
+            self._logger.info("Connected!\n\n")
             s.setblocking(False)
             return s
 
@@ -137,35 +152,39 @@ class Client:
     def _print_loading_animation(self):
         index = 0
         elapsed_seconds = 0
-        print('', end='\n')
+        print("", end="\n")
 
         while True:
             loading = "|/-\\"
-            sys.stdout.write("\rwaiting... {} (Time: {}:{}{})".format(
-                loading[index % len(loading)],
-                math.floor(elapsed_seconds) // 60,
-                "0" if math.floor(elapsed_seconds) % 60 < 10 else "",
-                math.floor(elapsed_seconds) % 60
-            ))
+            sys.stdout.write(
+                "\rwaiting... {} (Time: {}:{}{})".format(
+                    loading[index % len(loading)],
+                    math.floor(elapsed_seconds) // 60,
+                    "0" if math.floor(elapsed_seconds) % 60 < 10 else "",
+                    math.floor(elapsed_seconds) % 60,
+                )
+            )
             sys.stdout.flush()
-            time.sleep(.5)
-            elapsed_seconds += .5
+            time.sleep(0.5)
+            elapsed_seconds += 0.5
             index += 1
             if self.stop_loading_animation_event.is_set():
                 break
 
     def _prepare_request(self, upload_directory: str) -> str:
         file_list = get_filepaths(upload_directory)
-        target_filepath = os.path.join(upload_directory, 'build.zip')
-        pack(base_folder=upload_directory, origin=file_list, destination=target_filepath)
+        target_filepath = os.path.join(upload_directory, "build.zip")
+        pack(
+            base_folder=upload_directory, origin=file_list, destination=target_filepath
+        )
         request = serialize(target_filepath)
         unpack(target_filepath, self.download_dir)
         os.remove(target_filepath)
         return request
 
     def _process_response(self, data):
-        result_dir = self.download_dir + '/result'
-        zip_file = result_dir + '/result.zip'
+        result_dir = self.download_dir + "/result"
+        zip_file = result_dir + "/result.zip"
 
         os.mkdir(result_dir)
         deserialize(data, zip_file)
@@ -182,36 +201,43 @@ def find_bin_files(directory):
     bin_files = []
     for root, _, files in os.walk(directory):
         for file in files:
-            if file.lower().endswith('.bin'):
+            if file.lower().endswith(".bin"):
                 bin_files.append(file)
     return bin_files
 
 
-def parse_sys_argv(default_config_path):
-    username = sys.argv[1]
-    upload_data_folder = sys.argv[2]
-    model_number = sys.argv[3]
+def parse_sys_argv(default_config_path, argv):
+    username = argv[1]
+    upload_data_folder = argv[2]
+    model_number = argv[3]
 
-    for arg in sys.argv[4:]:
+    for arg in argv[4:]:
         if os.path.isdir(arg):
             download_data_folder = Path(arg)
             break
     else:
         download_data_folder = None
 
-    for arg in sys.argv[4:]:
+    for arg in argv[4:]:
         if arg.endswith(".toml"):
             config_path = Path(arg)
             break
     else:
         config_path = default_config_path
 
-    if '-b' in sys.argv:
+    if "-b" in sys.argv:
         only_bin_files = True
     else:
         only_bin_files = False
 
-    return username, upload_data_folder, model_number, download_data_folder, config_path, only_bin_files
+    return (
+        username,
+        upload_data_folder,
+        model_number,
+        download_data_folder,
+        config_path,
+        only_bin_files,
+    )
 
 
 def make_unique_dir(download_dir):
@@ -241,15 +267,28 @@ def main():
     Arguments download_dir, config_path and -b are optional.
     """
     logging.basicConfig(
-        level=logging.DEBUG, force=True,
-        format="{levelname}::{filename}:{lineno}:\t{message}", style="{",
+        level=logging.DEBUG,
+        force=True,
+        format="{levelname}::{filename}:{lineno}:\t{message}",
+        style="{",
     )
+    argv = sys.argv
+    if len(argv) not in (5, 6):
+        print(main.__doc__)
+        return
     default_config = Path("config/client_config.toml")
-    username, upload_data_folder, model_number, download_data_folder, config_path, only_bin_files = parse_sys_argv(default_config)
+    (
+        username,
+        upload_data_folder,
+        model_number,
+        download_data_folder,
+        config_path,
+        only_bin_files,
+    ) = parse_sys_argv(default_config, argv)
     client = Client.from_config(config_path)
     client.client_config.queue_user = username
     client.build(upload_data_folder, model_number, download_data_folder, only_bin_files)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Previously users had to open the source code to find out how to use the command line client. Now we (very primitively) check that the correct number of arguments have been passed and print the main functions docstring otherwise.